### PR TITLE
Application main page, remove top bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ yarn-error.*
 app-example
 android
 .env
+coverage

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,7 @@
 import { Stack } from "expo-router";
+import React from "react";
 
-export default function RootLayout() {
-  return <Stack />;
-}
+const RootLayout: React.FC = () => (
+  <Stack screenOptions={{ headerShown: true, title: "Poker Chips Helper" }} />
+);
+export default RootLayout;

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -6,7 +6,7 @@ import ChipsSelector from "@/components/ChipsSelector";
 import ChipDistributionSummary from "@/components/ChipDistributionSummary";
 import ChipDetection from "@/components/ChipDetection";
 
-const IndexScreen = () => {
+const IndexScreen: React.FC = () => {
   const [playerCount, setPlayerCount] = useState(2);
   const [buyInAmount, setBuyInAmount] = useState<number | null>(null);
   const [numberOfChips, setNumberOfChips] = useState<number>(5);
@@ -34,9 +34,6 @@ const IndexScreen = () => {
 
   return (
     <ScrollView contentContainerStyle={{ padding: 20, flexGrow: 1 }}>
-      <Text style={{ fontSize: 24, marginBottom: 30, marginTop: 50 }}>
-        Poker Chip Helper
-      </Text>
       <PlayerSelector
         playerCount={playerCount}
         setPlayerCount={setPlayerCount}


### PR DESCRIPTION
Addresses Issue #24 

This work addresses the issue we had of the expo router title bar simply saying "index". The issue was originally to remove the bar, but instead I decided to keep it and just change the name to our app name. I instead removed the redundant title within the page itself

I also added `coverage` to gitignore, which is automatically generated by `jest` when you test for code coverage.

Also some minor ts/js tweaks to set some code examples