### PR TITLE
Restores the previous state when reopened 

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,16 +1,35 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { ScrollView, Text, Alert, Button, View, StyleSheet } from "react-native";
 import PlayerSelector from "@/components/PlayerSelector";
 import BuyInSelector from "@/components/BuyInSelector";
 import ChipsSelector from "@/components/ChipsSelector";
 import ChipDistributionSummary from "@/components/ChipDistributionSummary";
 import { saveState, loadState } from "../components/CalculatorState";
+import { savePersistentState, loadPersistentState } from "../components/PersistentState";
 
 const IndexScreen = () => {
   const [playerCount, setPlayerCount] = useState(2);
   const [buyInAmount, setBuyInAmount] = useState<number | null>(null);
   const [numberOfChips, setNumberOfChips] = useState<number>(5);
   const [totalChipsCount, setTotalChipsCount] = useState<number[]>([]);
+
+  useEffect(() => {
+    const loadPersistentData = async () => {
+      const savedState = await loadPersistentState();
+      if (savedState) {
+        setPlayerCount(savedState.playerCount);
+        setBuyInAmount(savedState.buyInAmount);
+        setNumberOfChips(savedState.numberOfChips);
+        setTotalChipsCount(savedState.totalChipsCount);
+      }
+    };
+    loadPersistentData();
+  }, []);
+
+  useEffect(() => {
+    const state = { playerCount, buyInAmount, numberOfChips, totalChipsCount };
+    savePersistentState(state);
+  }, [playerCount, buyInAmount, numberOfChips, totalChipsCount]);
 
   const handleSave = async (slot: "SLOT1" | "SLOT2") => {
     if (buyInAmount === null) {

--- a/components/PersistentState.tsx
+++ b/components/PersistentState.tsx
@@ -1,0 +1,28 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const STORAGE_KEY = "@poker_calculator_state";
+
+export interface PokerState {
+  playerCount: number;
+  buyInAmount: number | null;
+  numberOfChips: number;
+  totalChipsCount: number[];
+}
+
+export const savePersistentState = async (state: PokerState) => {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    return { success: true, message: "State saved successfully" };
+  } catch (error) {
+    return { success: false, message: "Failed to save state" };
+  }
+};
+
+export const loadPersistentState = async (): Promise<PokerState | null> => {
+  try {
+    const storedState = await AsyncStorage.getItem(STORAGE_KEY);
+    return storedState ? JSON.parse(storedState) : null;
+  } catch (error) {
+    return null;
+  }
+};

--- a/components/__tests__/PersistentState.test.tsx
+++ b/components/__tests__/PersistentState.test.tsx
@@ -1,0 +1,53 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { saveState, loadState, PokerState } from "../CalculatorState";
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  setItem: jest.fn(),
+  getItem: jest.fn(),
+}));
+
+describe("CalculatorState.tsx", () => {
+  const mockState: PokerState = {
+    playerCount: 4,
+    buyInAmount: 50,
+    numberOfChips: 5,
+    totalChipsCount: [100, 200, 150, 50, 75],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should save state successfully", async () => {
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValueOnce(undefined);
+    const result = await saveState("SLOT1", mockState);
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("State saved to SLOT1");
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith("@poker_state_slot1", JSON.stringify(mockState));
+  });
+
+  it("should fail to save state if an error occurs", async () => {
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error("Failed to save"));
+    const result = await saveState("SLOT1", mockState);
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Failed to save state");
+  });
+
+  it("should load state successfully", async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockState));
+    const result = await loadState("SLOT1");
+    expect(result).toEqual(mockState);
+  });
+
+  it("should return null if no state is found", async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+    const result = await loadState("SLOT1");
+    expect(result).toBeNull();
+  });
+
+  it("should return null if an error occurs while loading state", async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error("Failed to load"));
+    const result = await loadState("SLOT1");
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
It ensures that when the application is reopened after being fully closed, it retains the previous state, including the number of players, buy-in amount, and chip distribution.